### PR TITLE
Add a json-navigator major mode and activate when displaying tree

### DIFF
--- a/json-navigator.el
+++ b/json-navigator.el
@@ -34,6 +34,9 @@
 (defvar json-navigator-display-length 3
   "Number of JSON elements to print for an array or object.")
 
+(define-derived-mode json-navigator-mode special-mode "Json Navigator"
+  "Major mode for json navigator")
+
 (defun json-navigator-object-p (json)
   "Return non-nil if JSON is an object."
   (or (null json)
@@ -171,7 +174,8 @@ instead of a full one."
   (switch-to-buffer
    (hierarchy-tree-display
     (json-navigator-create-hierarchy json)
-    (lambda (item _) (json-navigator--insert (json-navigator--unwrap item))))))
+    (lambda (item _) (json-navigator--insert (json-navigator--unwrap item)))))
+  (json-navigator-mode))
 
 ;;;###autoload
 (defun json-navigator-navigate-after-point ()


### PR DESCRIPTION
It's useful to be able to define a keymap and run hooks (like activating
tree-minor-mode) when a json-navigator buffer is opened.