### PR TITLE
Remove hierarchy from dependencies and require Emacs 28

### DIFF
--- a/json-navigator.el
+++ b/json-navigator.el
@@ -5,7 +5,7 @@
 ;; Author: Damien Cassou <damien@cassou.me>
 ;; URL: https://github.com/DamienCassou/json-navigator
 ;; Version: 0.1.1
-;; Package-Requires: ((emacs "25.1") (hierarchy "0.6.0"))
+;; Package-Requires: ((emacs "28.1"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
hierarchy is provided with Emacs 28 and beyond.